### PR TITLE
Add emit event for sync prop

### DIFF
--- a/src/ckeditor.vue
+++ b/src/ckeditor.vue
@@ -60,6 +60,7 @@ export default {
         let html = this.instance.getData()
         if (html !== this.value) {
           this.$emit('input', html)
+          this.$emit('update:value', html)
         }
       })
     }


### PR DESCRIPTION
Sync modifier is provided since Vue 2 since version 2.3.0 (http://vuejs.org/v2/guide/components.html#sync-Modifier). Adding the new event emitting would allow using the sync modifier.