### PR TITLE
Fix ckeditor reseting the cursor at the beging on setData.

### DIFF
--- a/src/ckeditor.vue
+++ b/src/ckeditor.vue
@@ -45,7 +45,7 @@ export default {
     value (val) {
       let html = this.instance.getData()
       if (val !== html) {
-        this.instance.setData(val)
+        this.instance.setData(val, null, true)
       }
     }
   },


### PR DESCRIPTION
We ran into a bug. The editor was reseting the cursor on input.
It may be something related to the version of the ckeditor that we were
using. Passing the extra parameters `internal` on the `setData` so all
extra events are suppressed helped with the issue.