### PR TITLE
Fix #39 value exists, v-model added but ckeditor area is empty.

### DIFF
--- a/src/VCkeditor.vue
+++ b/src/VCkeditor.vue
@@ -69,6 +69,9 @@ export default {
         }
 
         this.instance.setData(this.value)
+        this.instance.on('instanceReady', () => {
+          this.instance.setData(this.value)
+        })
         this.instance.on('change', this.onChange)
         this.instance.on('blur', this.onBlur)
         this.instance.on('focus', this.onFocus)


### PR DESCRIPTION
setData should be called when instance.status === 'ready'.
  Status 'loaded' means only CKEditor core loaded
  instead of being ready for interaction.
  See: https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR-event-instanceLoaded