### PR TITLE
Add instanceReadyCallback prop to allow attaching a custom instanceReady callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ export default {
 
 ### Props
 
-| Name           | Type     | Description                              |
-| -------------- | -------- | ---------------------------------------- |
-| `name`         | `String` | Name of instance ckedior. **Default: editor-1** |
-| `id`           | `String` | Id of instance ckedior. **Default: editor-1** |
-| `types`        | `String` | Types of ckedior. **Default: classic** |
-| `config`       | `Object` | All configuration of ckeditor. **Default: {}** |
+| Name                    | Type       | Description                              |
+| ----------------------- | ---------- | ---------------------------------------- |
+| `name`                  | `String`   | Name of instance ckedior. **Default: editor-1** |
+| `id`                    | `String`   | Id of instance ckedior. **Default: editor-1** |
+| `types`                 | `String`   | Types of ckedior. **Default: classic** |
+| `config`                | `Object`   | All configuration of ckeditor. **Default: {}** |
+| `instanceReadyCallback` | `Function` | Optional function that will be attached to CKEditor instanceReady event. |
 
 ## Build Setup
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,9 @@ export const VueCkeditor = (opts = {}) => {
       config: {
         type: Object,
         default: () => {}
+      },
+      instanceReadyCallback: {
+        type: Function
       }
     },
     data() {
@@ -91,6 +94,10 @@ export const VueCkeditor = (opts = {}) => {
               this.onChange;
             }, 0);
           });
+
+          if (typeof this.instanceReadyCallback != 'undefined') {
+            this.instance.on('instanceReady', this.instanceReadyCallback);
+          }
         }
       },
       update(val) {


### PR DESCRIPTION
This allows user to set a function that will be attached to CKEditor's instanceReady event.

It's useful because some events like fileUploadRequest can only be attached to the editor instance.

Here is an example:

```
<template>
  <div>
    <vue-ckeditor :instanceReadyCallback="ckEditorReadyCallback"></vue-ckeditor>
  </div>
</template>

<script>
export default {
  data() {
    return {
      ckEditorReadyCallback: function(readyEvent) {
        readyEvent.editor.on('fileUploadRequest', function(evt) {
          var xhr = evt.data.fileLoader.xhr

          xhr.setRequestHeader('My-Custom-Header', 'Example')
        }
      }
    }
  }
}
</script>

```