### PR TITLE
Added ability to make CkEditor readonly

### DIFF
--- a/src/VueCkeditor.vue
+++ b/src/VueCkeditor.vue
@@ -5,7 +5,8 @@
       :id="id"
       :value="value"
       :types="types"
-      :config="config">
+      :config="config"
+      :disabled="readOnlyMode">
     </textarea>
   </div>
 </template>
@@ -37,7 +38,11 @@ export default {
     },
     instanceReadyCallback: {
       type: Function
-    }
+    },
+    readOnlyMode: {
+      type: Boolean,
+      default: () => false,
+    },
   },
   data() {
     return {
@@ -57,6 +62,9 @@ export default {
           this.update(val);
         }
       } catch (e) {}
+    },
+    readOnlyMode(val) {
+      this.instance.setReadOnly(val);
     }
   },
   mounted() {


### PR DESCRIPTION
Added prop: `readOnlyMode`
Added watcher on the prop calling the editor instance method `setReadOnly`
textarea gets a `:disabled="readOnlyMode"` so the editor initializes in the proper mode.

ReadOnly mode information: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_readonly.html