### PR TITLE
Destroy ckeditor instance correctly.

### DIFF
--- a/src/VueCkeditor.vue
+++ b/src/VueCkeditor.vue
@@ -145,10 +145,8 @@ export default {
     destroy() {
       try {
         let editor = window['CKEDITOR'];
-        if (editor.instances) {
-          for (let instance in editor.instances) {
-            instance.destroy();
-          }
+        if (editor.instances && editor.instances[this.id]) {
+          editor.instances[this.id].destroy();
         }
       } catch (e) {}
     },


### PR DESCRIPTION
With the current code, in the destroy hook we loop over instances using
a for in loop. That yields the _keys_ to the loop, which we then call
destroy() on, which fails because it's just a string, not the actual
instance.

This code fixes it so that:

1. We call destroy correctly on the CKEDITOR instance.
2. We only destroy the id of the CKEDITOR instance that this component
   is actually showing. In the current code it would actually kill all
   CKEDITOR instances on the page, which is probably not desired.

I made 2 sample apps:

http://ckeditor-destroy-example.surge.sh/ shows an example with the
current code. In it you can see how when we force a new component to be
created (changing the :key) all the old ckeditor instances are still
there.

http://fixed-ckeditor-destroy.surge.sh/ is with this patch applied, and
you can see that the CKEDITOR instances do not grow.

https://gist.github.com/patrickdavey/266bf06b39237dcc40679978fdd229d4
shows a gist of the code I used to create these sample apps.