### PR TITLE
instanceValue not updated when updating editor value

### DIFF
--- a/src/VueCkeditor.vue
+++ b/src/VueCkeditor.vue
@@ -140,6 +140,7 @@ export default {
     update(val) {
       if (this.instanceValue !== val) {
         this.instance.setData(val, { internal: false });
+        this.instanceValue = val;
       }
     },
     destroy() {


### PR DESCRIPTION
The instanceValue data property isn't updated when you assign a new value. This has the effect of the editor not updating the actual value in CKeditor, because it thinks there's another value in the editor.